### PR TITLE
Issue when VCF file not in working directory

### DIFF
--- a/admixture.py
+++ b/admixture.py
@@ -11,7 +11,7 @@ import zipfile
 
 class Admixture():
 	'Class for operating on VCF file using VCFtools and Plink'
-	
+
 
 	def __init__(self, prefix, NP, minK, maxK, rep, cv):
 		self.prefix = prefix
@@ -49,9 +49,17 @@ class Admixture():
 				command_string = "admixture -j" + str(self.NP) + " -s " + str(np.random.randint(1000000)) + " --cv=" + str(self.cv) + " " + self.prefix + ".ped " + str(i)
 				#print(command_string)
 				self.run_program(command_string,i,j)
+
+				#Manually re-name output files to include _j rep number
+				# oldP = self.prefix + "." + str(i) + ".P"
+				# newP = self.prefix + "." + str(i) + "_" + str(j) + ".P"
+				# os.rename(oldP, newP)
+				# oldQ = self.prefix + "." + str(i) + ".Q"
+				# newQ = self.prefix + "." + str(i) + "_" + str(j) + ".Q"
+				# os.rename(oldQ, newQ)
 				for filename in os.listdir("."):
 					fn = self.prefix + "." + str(i) + "."
-					if filename.startswith(fn):
+					if fn in filename:
 						oldname, extension = os.path.splitext(filename)
 						newname = oldname + "_" + str(j) + extension
 						os.rename(filename, newname)
@@ -102,7 +110,7 @@ class Admixture():
 						fh.write("\n")
 				temp.close()
 		fh.close()
-		
+
 		try:
 			command="sort -n -k1 -o loglik.txt loglik.txt"
 			process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)

--- a/vcf.py
+++ b/vcf.py
@@ -15,7 +15,7 @@ class VCF():
 		self.thin = thin
 		self.maf = maf
 
-		temp = os.path.splitext(infile)
+		temp = os.path.splitext(os.path.basename(infile))
 		self.prefix = temp[0]
 
 	def run_program(self,string):


### PR DESCRIPTION
The String startwith() method used for renaming the output files [to add the replicate number extension to the .P and .Q files in Admixture.admix()] wasn't working when users called admixturePipeline with a VCF file that wasn't in the working directory, because the VCF.prefix method keeps the filepath of the VCF file. Since admixture writes to the working directory, admixturePIpeline wasn't finding the output files to rename them. Ended up just having the VCF.prefix() function return the basename, without path included