### PR TITLE
added indcov and snpcov filters

### DIFF
--- a/admixture.py
+++ b/admixture.py
@@ -35,6 +35,8 @@ class Admixture():
 				print("Non-zero exit status:")
 				print(process.returncode)
 				raise SystemExit
+		except (KeyboardInterrupt, SystemExit):
+			raise
 		except:
 			print("Unexpected error:")
 			print(sys.exc_info())

--- a/admixturePipeline.py
+++ b/admixturePipeline.py
@@ -9,11 +9,14 @@ import sys
 
 def main():
 	input = ComLine(sys.argv[1:])
-	vcf_file = VCF(input.args.vcf, input.args.thin, input.args.maf)
+	vcf_file = VCF(input.args.vcf, input.args.thin, input.args.maf, input.args.indcov, input.args.snpcov)
 	#if input.args.filter == True:
 	#	vcf_file.convert_filter()
 	#else:
+
+	#convert to Plink
 	vcf_file.convert()
+
 	populations = Popmap(input.args.popmap)
 	vcf_file.plink()
 	vcf_file.print_populations(populations)

--- a/comline.py
+++ b/comline.py
@@ -5,7 +5,7 @@ import os.path
 
 class ComLine():
 	'Class for implementing command line options'
-	
+
 
 	def __init__(self, args):
 		parser = argparse.ArgumentParser()
@@ -55,6 +55,18 @@ class ComLine():
 							default=0,
 							help="Use VCFtools to thin out loci falling within the specified proximity to one another."
 		)
+		opt_admix.add_argument("-C", "--indcov",
+							dest='indcov',
+							type=float,
+							default=0.9,
+							help="Specify the maximum allowable missing data per individual"
+		)
+		opt_admix.add_argument("-S", "--snpcov",
+							dest='snpcov',
+							type=float,
+							default=0.9,
+							help="Specify the maximum allowable missing data per SNP"
+		)
 		opt_admix.add_argument("-c", "--cv",
 							dest='cv',
 							type=int,
@@ -67,7 +79,7 @@ class ComLine():
 							default=20,
 							help="Number of replicates per K."
 		)
-		
+
 		self.args = parser.parse_args()
 
 		#check if files exist


### PR DESCRIPTION
Was running into issue where the pipeline cryptically failed ("Unexpected error") which was caused by admixture choking on a sample which had no data left in the filtered VCF file. Was able to figure it out by manually running the admixture command. Added <-C, --indcov> and <-S, --snpcov> options and associated methods in the VCF class for filtering out individuals and columns based on maximum allowable missing data. Figured it would be easier than doing this manually each time before running admixture. Seems to be working as desired so far. 