### PR TITLE
Fixed failure in cases where min(K) isn't 1

### DIFF
--- a/graphics.py
+++ b/graphics.py
@@ -12,19 +12,21 @@ class Graphics():
 
 
 	def printFigure(self):
-		data_to_plot = self.prepData()
+		(data_to_plot, klist) = self.prepData()
 
 		fig = matplotlib.pyplot.figure(1, figsize=(18,12))		
 		ax = fig.add_subplot(111)
-		bp=ax.boxplot(data_to_plot)
+		bp=ax.boxplot(data_to_plot, positions=klist)
 		fig.savefig(self.output, bbox_inches='tight')
 
 	def prepData(self):
 		lists = list()
-		for k,v in self.data.items():
+		klist=list()
+		for k, v in self.data.items():
 			templist = list()
+			klist.append(k)
 			for item in v:
 				templist.append(float(item))
 			lists.append(templist)
-
-		return lists
+		klist=sorted(klist)
+		return(lists, klist)

--- a/stats.py
+++ b/stats.py
@@ -8,7 +8,7 @@ import math
 class CVStats():
 	'Class for calculating summary statistics on CV output'
 	
-	def __init__(self, dictoflists,output):
+	def __init__(self, dictoflists, output):
 		self.output = output
 		self.d = dictoflists
 		self.dmeans = dict()
@@ -16,9 +16,11 @@ class CVStats():
 		self.dmed = dict()
 		self.dmin = dict()
 		self.dmax = dict()
+		self.klist = list()
 
 	def calcStats(self):
 		for k,l in self.d.items():
+			self.klist.append(k)
 			mean = self.calcMeans(l)
 			stdev = self.calcStdev(l,mean)
 			med = self.calcMed(l)
@@ -27,7 +29,8 @@ class CVStats():
 			self.dmed[k] = med
 			self.dmin[k] = min(l)
 			self.dmax[k] = max(l)
-	
+		self.klist = sorted(self.klist)
+		
 	def calcMeans(self,l):
 		total = self.calcSum(l)
 		mean = (total/len(l))
@@ -66,7 +69,7 @@ class CVStats():
 		fh = open(self.output, 'w')
 		print("K\tMean\tStDev\tMedian\tMin\tMax")
 		fh.write("K\tMean\tStDev\tMedian\tMin\tMax\n")
-		for k in range(1,len(self.dmeans.keys())+1):
+		for k in self.klist:
 			print(k, "\t", round(self.dmeans[k],5), "\t", round(self.dstdev[k],5), "\t", round(self.dmed[k],5), "\t", round(self.dmin[k],5), "\t", round(self.dmax[k],5))
 			fh.write(str(k))
 			fh.write("\t")


### PR DESCRIPTION
- Added a CVStats.klist attribute which is just a sorted list of k values so the printStats function won't fail when K doesn't range from 1 - max(K)
- Changed graphics.py to create a sorted klist in prepData, which is used as the x-axis label in the boxplot() function in printFigure(). 